### PR TITLE
refactor(hyprland): prepare for hyprland 0.53.0

### DIFF
--- a/home/dot_config/hypr/hyprland/rule.conf
+++ b/home/dot_config/hypr/hyprland/rule.conf
@@ -1,91 +1,78 @@
 # Common #
 # Floating
-windowrulev2 = float, floating:1
+windowrule = float on, match:float 1
 # Smart gaps
 workspace = w[tv1], gapsout:0, gapsin:0
 workspace = f[1], gapsout:0, gapsin:0
-windowrulev2 = bordersize 0, floating:0, onworkspace:w[tv1]
-windowrulev2 = rounding 0, floating:0, onworkspace:w[tv1]
-windowrulev2 = decorate off, floating:0, onworkspace:w[tv1]
-windowrulev2 = noshadow, floating:0, onworkspace:w[tv1]
-windowrulev2 = bordersize 0, floating:0, onworkspace:f[1]
-windowrulev2 = rounding 0, floating:0, onworkspace:f[1]
-windowrulev2 = decorate off, floating:0, onworkspace:f[1]
-windowrulev2 = noshadow, floating:0, onworkspace:f[1]
+windowrule = border_size 0, match:float 0, match:workspace w[tv1]
+windowrule = rounding 0, match:float 0, match:workspace w[tv1]
+windowrule = border_size 0, match:float 0, match:workspace f[1]
+windowrule = rounding 0, match:float 0, match:workspace f[1]
 # Fix dragging issues with XWayland
-windowrulev2 = nofocus,class:^$,title:^$,xwayland:1,floating:1,fullscreen:0,pinned:0
+windowrule = no_focus on, match:class ^$, match:title ^$, match:xwayland 1, match:float 1, match:fullscreen 0, match:pin 0
 
 # Per app #
 # Tags
-windowrulev2 = tag +term, class:^(kitty)$
-windowrulev2 = tag +browser, class:^([Ff]irefox(|-esr)|org.mozilla.firefox|[Ff]irefox)$
-windowrulev2 = tag +browser, class:^([Gg]oogle-chrome(-beta|-dev|-unstable)?)$
-windowrulev2 = tag +browser, class:^(chrome-.+-Default)$ # Chrome PWAs
-windowrulev2 = tag +browser, class:^(Vivaldi.+)$
-windowrulev2 = tag +browser, class:^([Zz]en)$
-windowrulev2 = tag +email, class:^(eu.betterbird.Betterbird)$
-windowrulev2 = tag +viewer, class:^(evince)$ # document viewer
-windowrulev2 = tag +viewer, class:^(eog|org.gnome.Loupe)$ # image viewer
-windowrulev2 = tag +im, class:^([Dd]iscord|[Ww]ebCord|[Vv]esktop)$
-windowrulev2 = tag +im, class:^([Ss]lack)$
-windowrulev2 = tag +im, class:^([Ff]erdium)$
-windowrulev2 = tag +im, class:^(org.telegram.desktop|io.github.tdesktop_x64.TDesktop)$
-windowrulev2 = tag +im, class:^(teams-for-linux)$
-windowrulev2 = tag +torrent, class:^(org.qbittorrent.qBittorrent)$
-windowrulev2 = tag +office, class:^([Cc]odium|libreoffice.*)$
-windowrulev2 = tag +office, class:^(obsidian)$
-windowrulev2 = tag +video, class:^(com.stremio.stremio|vlc|mpv)$
-windowrulev2 = tag +music, class:^(spotify)$
-windowrulev2 = tag +games, class:^(steam_app_\d+)$
-windowrulev2 = tag +games, class:^(steam_proton)$
-windowrulev2 = tag +gamestore, class:^(net.lutris.Lutris)$
-windowrulev2 = tag +gamestore, class:^([Ss]team)$
-windowrulev2 = tag +file-manager, class:^([Tt]hunar|org.gnome.Nautilus|[Pp]cmanfm-qt)$
-windowrulev2 = tag +file-manager, class:^(app.drey.Warp)$
-windowrulev2 = tag +vm, class:^(VirtualBox|virt-manager|qemu|remote-viewer)$
-windowrulev2 = tag +settings, class:^(file-roller|org.gnome.FileRoller)$ # archive manager
-windowrulev2 = tag +settings, class:^(nm-applet|nm-connection-editor|blueman-manager)$
-windowrulev2 = tag +settings, class:^(pavucontrol|org.pulseaudio.pavucontrol|com.saivert.pwvucontrol)$
-windowrulev2 = tag +settings, class:^(nwg-look|qt5ct|qt6ct|[Yy]ad)$
-windowrulev2 = tag +settings, class:(xdg-desktop-portal-gtk)
-windowrulev2 = tag +settings, class:(btop)
+windowrule = tag +term, match:class ^(kitty)$
+windowrule = tag +browser, match:class ^([Ff]irefox(|-esr)|org.mozilla.firefox|[Ff]irefox)$
+windowrule = tag +browser, match:class ^([Gg]oogle-chrome(-beta|-dev|-unstable)?)$
+windowrule = tag +browser, match:class ^(chrome-.+-Default)$ # Chrome PWAs
+windowrule = tag +browser, match:class ^(Vivaldi.+)$
+windowrule = tag +browser, match:class ^([Zz]en)$
+windowrule = tag +email, match:class ^(eu.betterbird.Betterbird)$
+windowrule = tag +viewer, match:class ^(evince)$ # document viewer
+windowrule = tag +viewer, match:class ^(eog|org.gnome.Loupe)$ # image viewer
+windowrule = tag +im, match:class ^([Dd]iscord|[Ww]ebCord|[Vv]esktop)$
+windowrule = tag +im, match:class ^([Ss]lack)$
+windowrule = tag +im, match:class ^([Ff]erdium)$
+windowrule = tag +im, match:class ^(org.telegram.desktop|io.github.tdesktop_x64.TDesktop)$
+windowrule = tag +im, match:class ^(teams-for-linux)$
+windowrule = tag +torrent, match:class ^(org.qbittorrent.qBittorrent)$
+windowrule = tag +office, match:class ^([Cc]odium|libreoffice.*)$
+windowrule = tag +office, match:class ^(obsidian)$
+windowrule = tag +video, match:class ^(com.stremio.stremio|vlc|mpv)$
+windowrule = tag +music, match:class ^(spotify)$
+windowrule = tag +games, match:class ^(steam_app_\d+)$
+windowrule = tag +games, match:class ^(steam_proton)$
+windowrule = tag +gamestore, match:class ^(net.lutris.Lutris)$
+windowrule = tag +gamestore, match:class ^([Ss]team)$
+windowrule = tag +file-manager, match:class ^([Tt]hunar|org.gnome.Nautilus|[Pp]cmanfm-qt)$
+windowrule = tag +file-manager, match:class ^(app.drey.Warp)$
+windowrule = tag +vm, match:class ^(VirtualBox|virt-manager|qemu|remote-viewer)$
+windowrule = tag +settings, match:class ^(file-roller|org.gnome.FileRoller)$ # archive manager
+windowrule = tag +settings, match:class ^(nm-applet|nm-connection-editor|blueman-manager)$
+windowrule = tag +settings, match:class ^(pavucontrol|org.pulseaudio.pavucontrol|com.saivert.pwvucontrol)$
+windowrule = tag +settings, match:class ^(nwg-look|qt5ct|qt6ct|[Yy]ad)$
+windowrule = tag +settings, match:class (xdg-desktop-portal-gtk)
+windowrule = tag +settings, match:class (btop)
 
 # Handle workspace
-windowrulev2 = workspace name:term silent, tag:term*
-windowrulev2 = workspace name:web silent, tag:browser*
-windowrulev2 = workspace name:mail silent, tag:email*
-windowrulev2 = workspace name:chat silent, tag:im*
-windowrulev2 = workspace name:media silent, tag:music*
-windowrulev2 = workspace name:games silent, tag:games*
-windowrulev2 = workspace name:games silent, tag:gamestore*
-windowrulev2 = workspace name:office silent, tag:office*
-windowrulev2 = workspace name:others silent, tag:file-manager*
-windowrulev2 = workspace name:others silent, tag:viewer*
-windowrulev2 = workspace name:others silent, tag:torrent*
-windowrulev2 = workspace name:vm silent, tag:vm*
+windowrule = workspace name:term silent, match:tag term*
+windowrule = workspace name:web silent, match:tag browser*
+windowrule = workspace name:mail silent, match:tag email*
+windowrule = workspace name:chat silent, match:tag im*
+windowrule = workspace name:media silent, match:tag music*
+windowrule = workspace name:games silent, no_blur on, match:tag games*
+windowrule = workspace name:games silent, match:tag gamestore*
+windowrule = workspace name:office silent, match:tag office*
+windowrule = workspace name:others silent, match:tag file-manager*
+windowrule = workspace name:others silent, float on, match:tag viewer*
+windowrule = workspace name:others silent, match:tag torrent*
+windowrule = workspace name:vm silent, match:tag vm*
 
 # Floating for some apps
-windowrulev2 = float, tag:settings*
-windowrulev2 = float, tag:viewer*
-windowrulev2 = float, initialTitle:^(Calendar Reminders)$
-windowrulev2 = float, title:^(Picture-in-Picture)$
-windowrulev2 = float, class:^(mpv)$
+windowrule = float on, match:tag settings*
+windowrule = float on, match:initial_title ^(Calendar Reminders)$
+windowrule = float on, keep_aspect_ratio on, pin on, move ((monitor_w*0.72)) ((monitor_h*0.07)), match:title ^(Picture-in-Picture)$
+windowrule = float on, match:class ^(mpv)$
 # Size
-windowrulev2 = size 80% 70%, tag:setting*
-windowrulev2 = keepaspectratio, title:^(Picture-in-Picture)$
+windowrule = size (monitor_w*0.8) (monitor_h*0.7), center on, match:tag setting*
 # Pin
-windowrulev2 = pin, title:^(Picture-in-Picture)$
 # Position
-windowrulev2 = center, tag:setting*
-windowrulev2 = move 72% 7%, title:^(Picture-in-Picture)$
 # Blur and fullscreen
-windowrulev2 = noblur, tag:games*
 
 # Layer
-layerrule = blur, wofi
-layerrule = ignorezero, wofi
-layerrule = blur, swaync-control-center
-layerrule = ignorezero, swaync-control-center
-layerrule = blur, gtk-layer-shell
-layerrule = ignorezero, gtk-layer-shell
-layerrule = noanim, selection
+layerrule = blur on, ignore_alpha 0, match:namespace wofi
+layerrule = blur on, ignore_alpha 0, match:namespace swaync-control-center
+layerrule = blur on, ignore_alpha 0, match:namespace gtk-layer-shell
+layerrule = no_anim on, match:namespace selection

--- a/home/dot_config/hypr/hyprland/rule.conf
+++ b/home/dot_config/hypr/hyprland/rule.conf
@@ -43,8 +43,8 @@ windowrule = tag +settings, match:class ^(file-roller|org.gnome.FileRoller)$ # a
 windowrule = tag +settings, match:class ^(nm-applet|nm-connection-editor|blueman-manager)$
 windowrule = tag +settings, match:class ^(pavucontrol|org.pulseaudio.pavucontrol|com.saivert.pwvucontrol)$
 windowrule = tag +settings, match:class ^(nwg-look|qt5ct|qt6ct|[Yy]ad)$
-windowrule = tag +settings, match:class (xdg-desktop-portal-gtk)
-windowrule = tag +settings, match:class (btop)
+windowrule = tag +settings, match:class ^(xdg-desktop-portal-gtk)$
+windowrule = tag +settings, match:class ^(btop)$
 
 # Handle workspace
 windowrule = workspace name:term silent, match:tag term*
@@ -66,7 +66,7 @@ windowrule = float on, match:initial_title ^(Calendar Reminders)$
 windowrule = float on, keep_aspect_ratio on, pin on, move ((monitor_w*0.72)) ((monitor_h*0.07)), match:title ^(Picture-in-Picture)$
 windowrule = float on, match:class ^(mpv)$
 # Size
-windowrule = size (monitor_w*0.8) (monitor_h*0.7), center on, match:tag setting*
+windowrule = size (monitor_w*0.8) (monitor_h*0.7), center on, match:tag settings*
 # Pin
 # Position
 # Blur and fullscreen

--- a/home/dot_config/hypr/hyprpaper.conf.tmpl
+++ b/home/dot_config/hypr/hyprpaper.conf.tmpl
@@ -1,9 +1,15 @@
 {{- $id := printf "%s_%s" .place .kind }}
 {{- if eq $id "HOME_pc" }}
-preload   =   {{ .chezmoi.homeDir }}/Wallpapers/16:10/1729210197784.png
-wallpaper =   DP-2,contain:{{ .chezmoi.homeDir }}/Wallpapers/16:10/1729210197784.png
+wallpaper {
+  monitor = DP-2
+  path = {{ .chezmoi.homeDir }}/Wallpapers/16:10/1729210197784.png
+  fit_mode = contain
+}
 {{- else if eq $id "OFFICE_pc" }}
-preload   =   {{ .chezmoi.homeDir }}/Wallpapers/vertical/4.png
-wallpaper =   HDMI-A-1,contain:{{ .chezmoi.homeDir }}/Wallpapers/vertical/4.png
+wallpaper {
+  monitor = HDMI-A-1
+  path = {{ .chezmoi.homeDir }}/Wallpapers/vertical/4.png
+  fit_mode = contain
+}
 {{- end }}
-ipc       =   off
+ipc = off

--- a/home/executable_dot_wayland_init.fish.tmpl
+++ b/home/executable_dot_wayland_init.fish.tmpl
@@ -6,4 +6,4 @@ export XDG_RUNTIME_DIR=/tmp/user-$(id -u)
 export XDG_RUNTIME_DIR=/run/user/$(id -u)
 {{- end }}
 mkdir -p $XDG_RUNTIME_DIR && chmod 700 $XDG_RUNTIME_DIR
-dbus-run-session Hyprland
+dbus-run-session start-hyprland

--- a/root/etc/greetd/executable_start.sh.tmpl
+++ b/root/etc/greetd/executable_start.sh.tmpl
@@ -7,4 +7,4 @@ export XDG_RUNTIME_DIR=/run/user/$(id -u)
 {{- end }}
 export HOME=$XDG_RUNTIME_DIR
 mkdir -p $XDG_RUNTIME_DIR && chmod 700 $XDG_RUNTIME_DIR
-dbus-run-session Hyprland --config /etc/greetd/hyprland.conf
+dbus-run-session start-hyprland -- -c /etc/greetd/hyprland.conf


### PR DESCRIPTION
## Summary by Sourcery

Update Hyprland-related configuration files to align with the 0.53.0 syntax and startup expectations.

Enhancements:
- Migrate window and layer rules from legacy v2 syntax to the new match-based Hyprland rule format, including updated property names and options.
- Update hyprpaper wallpaper configuration to the new block-based wallpaper syntax with explicit monitor, path, and fit_mode fields.
- Change Wayland and greetd startup scripts to launch Hyprland via the start-hyprland wrapper and adjust CLI arguments accordingly.